### PR TITLE
Add support for SPM

### DIFF
--- a/BlowinSwiper.xcodeproj/project.pbxproj
+++ b/BlowinSwiper.xcodeproj/project.pbxproj
@@ -288,7 +288,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -311,7 +311,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = TakumaHoriuchi.BlowinSwiper;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/BlowinSwiper/BlowinSwiper.swift
+++ b/BlowinSwiper/BlowinSwiper.swift
@@ -104,7 +104,7 @@ extension BlowinSwiper: UIGestureRecognizerDelegate {
 extension BlowinSwiper: UINavigationControllerDelegate {
 
     public func navigationController(_ navigationController: UINavigationController,
-                                     animationControllerFor operation: UINavigationControllerOperation,
+                                     animationControllerFor operation: UINavigationController.Operation,
                                      from fromVC: UIViewController,
                                      to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         switch operation {

--- a/BlowinSwiper/BlowinSwiper.swift
+++ b/BlowinSwiper/BlowinSwiper.swift
@@ -30,10 +30,12 @@ public final class BlowinSwiper: NSObject {
     private var isInteractivePop = false
     private var isDecideBack = false
     private var isOnceGestureBegan = true
+    private var deferredDelegate: UINavigationControllerDelegate?
 
     public init(navigationController: UINavigationController?) {
         super.init()
         self.navigationController = navigationController
+        self.deferredDelegate = navigationController?.delegate
 
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
         panGesture.delegate = self
@@ -102,22 +104,50 @@ extension BlowinSwiper: UIGestureRecognizerDelegate {
 }
 
 extension BlowinSwiper: UINavigationControllerDelegate {
+    public func navigationController(_ navigationController: UINavigationController,
+                                     willShow viewController: UIViewController,
+                                     animated: Bool) {
+      deferredDelegate?.navigationController?(navigationController, willShow: viewController, animated: animated)
+    }
+
+    public func navigationController(_ navigationController: UINavigationController,
+                                     didShow viewController: UIViewController,
+                                     animated: Bool) {
+      deferredDelegate?.navigationController?(navigationController, didShow: viewController, animated: animated)
+    }
 
     public func navigationController(_ navigationController: UINavigationController,
                                      animationControllerFor operation: UINavigationController.Operation,
                                      from fromVC: UIViewController,
                                      to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        let deferredValue = deferredDelegate?.navigationController?(
+          navigationController, animationControllerFor: operation, from: fromVC, to: toVC
+        )
         switch operation {
         case .pop:
             return PopAnimatedTransitioning(isInteractivePop: isInteractivePop)
 
         default:
-            return nil
+            return deferredValue
         }
     }
 
     public func navigationController(_ navigationController: UINavigationController,
                                      interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        return isInteractivePop ? percentDriven : nil
+      return isInteractivePop
+        ? percentDriven
+        : deferredDelegate?.navigationController?(navigationController, interactionControllerFor: animationController)
+    }
+
+    public func navigationControllerSupportedInterfaceOrientations(
+      _ navigationController: UINavigationController
+    ) -> UIInterfaceOrientationMask {
+      return deferredDelegate?.navigationControllerSupportedInterfaceOrientations?(navigationController) ?? [.all]
+    }
+
+    public func navigationControllerPreferredInterfaceOrientationForPresentation(
+      _ navigationController: UINavigationController
+    ) -> UIInterfaceOrientation {
+      return deferredDelegate?.navigationControllerPreferredInterfaceOrientationForPresentation?(navigationController) ?? .unknown
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "BlowinSwiper",
+  products: [
+    // Products define the executables and libraries produced by a package, and make them visible to other packages.
+    .library(
+      name: "BlowinSwiper",
+      targets: ["BlowinSwiper"]
+    ),
+  ],
+  targets: [
+    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+    // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+    .target(
+      name: "BlowinSwiper",
+      dependencies: [],
+      path: "BlowinSwiper"
+    ),
+  ]
+)


### PR DESCRIPTION
- Add Package.swift to support Swift Package Manager.
- Update library's SWIFT_VERSION to Swift 5 and udpate reference of `UINavigationControllerOperation` to `UINavigationController.Operation`.